### PR TITLE
DRYD-1276: Add price information fields to acquisition form.

### DIFF
--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -37,16 +37,42 @@ const template = (configContext) => {
             <Field name="acquisitionSources">
               <Field name="acquisitionSource" />
             </Field>
-
-            <Field name="creditLine" />
           </Col>
 
           <Col>
-            <Field name="acquisitionReason" />
-            <Field name="acquisitionNote" />
-            <Field name="acquisitionProvisos" />
+            <Panel name="priceInformation">
+              <InputTable name="groupPurchasePrice">
+                <Field name="groupPurchasePriceCurrency" />
+                <Field name="groupPurchasePriceValue" />
+              </InputTable>
+
+              <InputTable name="objectOfferPrice">
+                <Field name="objectOfferPriceCurrency" />
+                <Field name="objectOfferPriceValue" />
+              </InputTable>
+
+              <InputTable name="objectPurchaseOfferPrice">
+                <Field name="objectPurchaseOfferPriceCurrency" />
+                <Field name="objectPurchaseOfferPriceValue" />
+              </InputTable>
+
+              <InputTable name="objectPurchasePrice">
+                <Field name="objectPurchasePriceCurrency" />
+                <Field name="objectPurchasePriceValue" />
+              </InputTable>
+
+              <InputTable name="originalObjectPurchasePrice">
+                <Field name="originalObjectPurchasePriceCurrency" />
+                <Field name="originalObjectPurchasePriceValue" />
+              </InputTable>
+            </Panel>
           </Col>
         </Cols>
+
+        <Field name="creditLine" />
+        <Field name="acquisitionReason" />
+        <Field name="acquisitionNote" />
+        <Field name="acquisitionProvisos" />
       </Panel>
 
       <Panel name="objectCollectionInformation" collapsible collapsed>


### PR DESCRIPTION
**What does this do?**

This adds the Price Information block of fields to the acquisition form. These were previously removed from the materials tenant. It also moves fields so to make room for the price information fields, resulting in a layout that is similar to the layout in the core tenant.

**Why are we doing this? (with JIRA link)**

https://collectionspace.atlassian.net/browse/DRYD-1276

**How should this be tested? Do these changes have associated tests?**

- Create an Acquisition record.
   On the top right side of the form, the Price Information block of fields should appear.
- Fill in the Reference Number and one or more of the Price Information fields, and save.
   The fields should save successfully.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.
