### PR TITLE
Update Layouts For Multiline Notes

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -91,10 +91,14 @@ const template = (configContext) => {
 
         <Field name="annotationGroupList" subpath="ns2:collectionobjects_annotation">
           <Field name="annotationGroup">
-            <Field name="annotationType" />
-            <Field name="annotationNote" />
-            <Field name="annotationDate" />
-            <Field name="annotationAuthor" />
+            <Panel>
+              <Row>
+                <Field name="annotationType" />
+                <Field name="annotationDate" />
+                <Field name="annotationAuthor" />
+              </Row>
+              <Field name="annotationNote" />
+            </Panel>
           </Field>
         </Field>
       </Panel>

--- a/src/plugins/recordTypes/loanout/forms/default.jsx
+++ b/src/plugins/recordTypes/loanout/forms/default.jsx
@@ -35,11 +35,15 @@ const template = (configContext) => {
 
         <Field name="loanStatusGroupList">
           <Field name="loanStatusGroup">
-            <Field name="loanGroup" />
-            <Field name="loanIndividual" />
-            <Field name="loanStatus" />
-            <Field name="loanStatusDate" />
-            <Field name="loanStatusNote" />
+            <Panel>
+              <Row>
+                <Field name="loanGroup" />
+                <Field name="loanIndividual" />
+                <Field name="loanStatus" />
+                <Field name="loanStatusDate" />
+              </Row>
+              <Field name="loanStatusNote" />
+            </Panel>
           </Field>
         </Field>
 


### PR DESCRIPTION
**What does this do?**
* Update the annotation groups to allow for multiline notes
* Update the loan groups to allow for multiline notes

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1284
Jira: https://collectionspace.atlassian.net/browse/DRYD-1285

This allows the `annotationNote` to be more useful in practice as users will be able to add useful information to the field. 

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Go to create a new procedure (loanout, collectionobject) with the new layout see the annotation group with multiline input for the note
* Create the new procedure with the annotation group fields filled out and verify it saves/reloads

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance