### PR TITLE
Revert display for objectCount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "chai-as-promised": "^5.3.0",
         "chai-immutable": "^1.6.0",
         "cross-env": "^2.0.0",
-        "cspace-ui": "^9.0.0-rc.2",
+        "cspace-ui": "^9.0.0-rc.3",
         "css-loader": "^6.7.3",
         "eslint": "^6.7.2",
         "eslint-config-airbnb": "^18.0.1",
@@ -3963,9 +3963,9 @@
       "dev": true
     },
     "node_modules/cspace-ui": {
-      "version": "9.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/cspace-ui/-/cspace-ui-9.0.0-rc.2.tgz",
-      "integrity": "sha512-KjFlZQ+50Ta6CA3QmrvTtmYwvK52rmmmYkIZiv41OsP1q80TqOy1nLumZx9JN9JcE8ajaTRlel2DH3B1AtYhVQ==",
+      "version": "9.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cspace-ui/-/cspace-ui-9.0.0-rc.3.tgz",
+      "integrity": "sha512-/JN8t3ECArdrUPvfL9A7C8GNMtF9Ao7Qv2nRRPARgJtkJfBgwAG8YlBKIREeUTqEQOd/BGCFiX6SonQeeKPDXA==",
       "dev": true,
       "dependencies": {
         "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "chai-as-promised": "^5.3.0",
     "chai-immutable": "^1.6.0",
     "cross-env": "^2.0.0",
-    "cspace-ui": "^9.0.0-rc.2",
+    "cspace-ui": "^9.0.0-rc.3",
     "css-loader": "^6.7.3",
     "eslint": "^6.7.2",
     "eslint-config-airbnb": "^18.0.1",

--- a/src/messages.js
+++ b/src/messages.js
@@ -12,7 +12,8 @@ export default {
   'column.collectionobject.narrow.objectNumber': 'Acc. number',
 
   'field.collectionobjects_common.objectNumber.name': 'Accession number',
-  'field.collectionobjects_common.objectCountGroup.name': 'Number of objects',
+  'field.collectionobjects_common.objectCount.fullName': 'Number of objects',
+  'field.collectionobjects_common.objectCount.name': 'Number of objects',
   'field.collectionobjects_common.briefDescription.name': 'Production description',
   'field.collectionobjects_common.objectStatus.name': 'Object type',
   'field.collectionobjects_common.reference.name': 'Supplementary literature description',

--- a/src/messages.js
+++ b/src/messages.js
@@ -12,6 +12,7 @@ export default {
   'column.collectionobject.narrow.objectNumber': 'Acc. number',
 
   'field.collectionobjects_common.objectNumber.name': 'Accession number',
+  'field.collectionobjects_common.objectCountGroup.name': 'Number of objects',
   'field.collectionobjects_common.briefDescription.name': 'Production description',
   'field.collectionobjects_common.objectStatus.name': 'Object type',
   'field.collectionobjects_common.reference.name': 'Supplementary literature description',

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -47,6 +47,16 @@ export default (configContext) => {
             },
           },
         },
+        objectCountGroupList: {
+          objectCountGroup: {
+            [config]: {
+              repeating: false,
+              props: {
+                tabular: false,
+              },
+            },
+          },
+        },
         physicalDescription: {
           // Replaced by materialPhysicalDescriptions. Hide from search.
           [config]: {

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -47,16 +47,6 @@ export default (configContext) => {
             },
           },
         },
-        objectCountGroupList: {
-          objectCountGroup: {
-            [config]: {
-              repeating: false,
-              props: {
-                tabular: false,
-              },
-            },
-          },
-        },
         physicalDescription: {
           // Replaced by materialPhysicalDescriptions. Hide from search.
           [config]: {

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -23,11 +23,7 @@ const template = (configContext) => {
         <Row>
           <Col>
             <Field name="objectNumber" />
-            <Field name="objectCountGroupList">
-              <Field name="objectCountGroup" tabular={false}>
-                <Field name="objectCount" label="" />
-              </Field>
-            </Field>
+            <Field name="objectCount" subpath={["ns2:collectionobjects_common", "objectCountGroupList", "objectCountGroup", "0"]} />
 
             <Field name="otherNumberList">
               <Field name="otherNumber">

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -23,7 +23,7 @@ const template = (configContext) => {
         <Row>
           <Col>
             <Field name="objectNumber" />
-            <Field name="objectCount" subpath={["ns2:collectionobjects_common", "objectCountGroupList", "objectCountGroup", "0"]} />
+            <Field name="objectCount" subpath={['ns2:collectionobjects_common', 'objectCountGroupList', 'objectCountGroup', '0']} />
 
             <Field name="otherNumberList">
               <Field name="otherNumber">

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -23,6 +23,11 @@ const template = (configContext) => {
         <Row>
           <Col>
             <Field name="objectNumber" />
+            <Field name="objectCountGroupList">
+              <Field name="objectCountGroup" tabular={false}>
+                <Field name="objectCount" label="" />
+              </Field>
+            </Field>
 
             <Field name="otherNumberList">
               <Field name="otherNumber">
@@ -98,16 +103,6 @@ const template = (configContext) => {
               </Row>
               <Field name="annotationNote" />
             </Panel>
-          </Field>
-        </Field>
-
-        <Field name="objectCountGroupList">
-          <Field name="objectCountGroup">
-            <Field name="objectCount" />
-            <Field name="objectCountType" />
-            <Field name="objectCountCountedBy" />
-            <Field name="objectCountDate" />
-            <Field name="objectCountNote" />
           </Field>
         </Field>
       </Panel>


### PR DESCRIPTION
**What does this do?**
Revert the display for objectCount to numberOfObjects

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1405

For material order, object count is aligned with library holdings and as such is better thought of with the pre-8.0 numberOfObjects. 

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* See `Number of objects` under object name
* Verify that `Number of objects` can save/load

**Dependencies for merging? Releasing to production?**
Since this is relabeling the objectCount field, it might be good to update other messages so that search and export are consistent. 

**Has the application documentation been updated for these changes?**
No, but I believe the chanelog will need be updated to reflect this.

**Did someone actually run this code to verify it works?**
@mikejritter tested locally