### PR TITLE
DRYD-1403: Use 7.2 publicbrowser template

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/index.js
+++ b/src/plugins/recordTypes/collectionobject/forms/index.js
@@ -1,9 +1,11 @@
 import defaultForm from './default';
 import miniForm from './mini';
+import publicForm from './public';
 
 export default (configContext) => ({
   default: defaultForm(configContext),
   mini: miniForm(configContext),
+  public: publicForm(configContext),
   inventory: {
     disabled: true,
   },

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -1,5 +1,3 @@
-import { defineMessages } from 'react-intl';
-
 const template = (configContext) => {
   const {
     React,

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -155,12 +155,5 @@ const template = (configContext) => {
 };
 
 export default (configContext) => ({
-  messages: defineMessages({
-    name: {
-      id: 'form.collectionobject.public.name',
-      defaultMessage: 'Public Browser Template',
-    },
-  }),
-  sortOrder: 3,
   template: template(configContext),
 });

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -1,0 +1,166 @@
+import { defineMessages } from 'react-intl';
+
+const template = (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Col,
+    Panel,
+    Row,
+  } = configContext.layoutComponents;
+
+  const {
+    Field,
+  } = configContext.recordComponents;
+
+  const {
+    extensions,
+  } = configContext.config;
+
+  return (
+    <Field name="document">
+      <Panel name="id" collapsible>
+        <Row>
+          <Col>
+            <Field name="objectNumber" />
+
+            <Field name="responsibleDepartments">
+              <Field name="responsibleDepartment" />
+            </Field>
+          </Col>
+
+          <Col>
+            <Field name="briefDescriptions">
+              <Field name="briefDescription" />
+            </Field>
+          </Col>
+        </Row>
+
+        <Field name="titleGroupList">
+          <Field name="titleGroup">
+            <Panel>
+              <Row>
+                <Col>
+                  <Field name="title" />
+                  <Field name="titleLanguage" />
+                </Col>
+
+                <Col>
+                  <Field name="titleType" />
+
+                  <Field name="titleTranslationSubGroupList">
+                    <Field name="titleTranslationSubGroup">
+                      <Field name="titleTranslation" />
+                      <Field name="titleTranslationLanguage" />
+                    </Field>
+                  </Field>
+                </Col>
+              </Row>
+            </Panel>
+          </Field>
+        </Field>
+
+        <Field name="objectNameList">
+          <Field name="objectNameGroup">
+            <Field name="objectName" />
+            <Field name="objectNameCurrency" />
+            <Field name="objectNameLevel" />
+            <Field name="objectNameSystem" />
+            <Field name="objectNameType" />
+            <Field name="objectNameLanguage" />
+            <Field name="objectNameNote" />
+          </Field>
+        </Field>
+      </Panel>
+
+      <Panel name="desc" collapsible>
+        <Field name="colors">
+          <Field name="color" />
+        </Field>
+
+        <Field name="materialGroupList">
+          <Field name="materialGroup">
+            <Field name="material" />
+            <Field name="materialComponent" />
+            <Field name="materialComponentNote" />
+            <Field name="materialName" />
+            <Field name="materialSource" />
+          </Field>
+        </Field>
+
+        {extensions.dimension.form}
+
+        <Panel name="content" collapsible>
+          <Field name="contentConcepts">
+            <Field name="contentConcept" />
+          </Field>
+        </Panel>
+      </Panel>
+
+      <Panel name="prod" collapsible>
+        <Row>
+          <Col>
+            <Field name="objectProductionDateGroupList">
+              <Field name="objectProductionDateGroup" />
+            </Field>
+
+            <Field name="objectProductionPlaceGroupList">
+              <Field name="objectProductionPlaceGroup">
+                <Field name="objectProductionPlace" />
+                <Field name="objectProductionPlaceRole" />
+              </Field>
+            </Field>
+          </Col>
+
+          <Col>
+            <Field name="objectProductionPeopleGroupList">
+              <Field name="objectProductionPeopleGroup">
+                <Field name="objectProductionPeople" />
+                <Field name="objectProductionPeopleRole" />
+              </Field>
+            </Field>
+
+            <Field name="objectProductionPersonGroupList">
+              <Field name="objectProductionPersonGroup">
+                <Field name="objectProductionPerson" />
+                <Field name="objectProductionPersonRole" />
+              </Field>
+            </Field>
+
+            <Field name="objectProductionOrganizationGroupList">
+              <Field name="objectProductionOrganizationGroup">
+                <Field name="objectProductionOrganization" />
+                <Field name="objectProductionOrganizationRole" />
+              </Field>
+            </Field>
+          </Col>
+        </Row>
+      </Panel>
+
+      <Panel name="hist" collapsible>
+        <Field name="objectHistoryNote" />
+      </Panel>
+
+      <Panel name="owner" collapsible>
+        <Field name="ownersContributionNote" />
+      </Panel>
+
+      <Panel name="viewer" collapsible>
+        <Field name="viewersContributionNote" />
+      </Panel>
+    </Field>
+  );
+};
+
+export default (configContext) => ({
+  messages: defineMessages({
+    name: {
+      id: 'form.collectionobject.public.name',
+      defaultMessage: 'Public Browser Template',
+    },
+  }),
+  sortOrder: 3,
+  template: template(configContext),
+});


### PR DESCRIPTION
**What does this do?**
Uses the 7.2 publicbrowser template

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1403

8.0 introduced some new fields which are not used by the materials profile: objectNameControlled, materialControlled, and objectCountGroupList. All these fields were brought in by the core public browser template and needed to be removed.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Create a collectionobject using the publicbrowser template and see that objectNameControlled, materialControlled, and objectCountGroupList do not exist
* Git can also be used to verify the template only contains those changes compared to cspace-ui:
```
git diff --no-index ${CSPACE_UI}/src/plugins/recordTypes/collectionobject/forms/public.jsx src/plugins/recordTypes/collectionobject/forms/public.jsx
```

**Dependencies for merging? Releasing to production?**
Holdings is used in the public browser for materials but isn't present on the template. We should consider adding the indexed objectCount field to the template. `contentConcepts` also isn't usable in the template and should be considered for removal. 

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally