### PR TITLE
DRYD-1419: Remove non-indexed materials fields

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -79,12 +79,8 @@ const template = (configContext) => {
         </Field>
 
         <Field name="materialGroupList">
-          <Field name="materialGroup">
-            <Field name="material" />
-            <Field name="materialComponent" />
-            <Field name="materialComponentNote" />
-            <Field name="materialName" />
-            <Field name="materialSource" />
+          <Field name="materialGroup" tabular={false}>
+            <Field name="material" label="" embedded />
           </Field>
         </Field>
 


### PR DESCRIPTION
**What does this do?**
* Removes fields from the Public Browser template which are not indexed

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1419

This removes fields which are not included in the elasticsearch index. This could confuse users if they try to populate the fields which will never show up in the public browser.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver with dev as a backend, e.g.
```
npm run devserver --back-end=https://materials.dev.collectionspace.org
```
* Create a CollectionObject
* Navigate to the Public Browser template
* See that the materials group only contains a single entry

**Dependencies for merging? Releasing to production?**
It probably doesn't make sense for the field to occupy the full width of the form, but something which can be sorted out later.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested using dev as a backend