### PR TITLE
DRYD-2008: Procedure > Acquisition > Create new Acquisition Description field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v4.0.2
+
+v4.0.2 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.2.0
+
+### Changes
+
+- Added the Acquisition description free text field (`acquisitionDescription`) to the record editor for Acquisitions.
+
 ## v4.0.1
 
 - Remove non-indexed material fields from the public browser template

--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -72,7 +72,6 @@ const template = (configContext) => {
         <Field name="creditLine" />
 
         <Field name="acquisitionDescription" />
-
         <Field name="acquisitionReason" />
         <Field name="acquisitionNote" />
         <Field name="acquisitionProvisos" />

--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -70,6 +70,9 @@ const template = (configContext) => {
         </Cols>
 
         <Field name="creditLine" />
+
+        <Field name="acquisitionDescription" />
+
         <Field name="acquisitionReason" />
         <Field name="acquisitionNote" />
         <Field name="acquisitionProvisos" />


### PR DESCRIPTION
**What does this do?**
Adds a new field, acquisition description

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2008

This is a field which is needed for an upcoming data migration.

**How should this be tested? Do these changes have associated tests?**
1. Run the devserver with the https://github.com/collectionspace/application/pull/334 and the https://github.com/collectionspace/cspace-ui.js/pull/332 (should both be merged to `develop` branches by now).
2. Create a new Acquisition
3. Populate the new field under Acquisition Information > Acquisition description
4. Save and reload to ensure the field populated
5. Use the AdvancedSearch for an Acquisition
6. Verify that the field shows up under the fields

**Dependencies for merging? Releasing to production?**
Should be released along with https://github.com/collectionspace/application/pull/334 https://github.com/collectionspace/cspace-ui.js/pull/332

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally