### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## v4.0.2
+## v4.1.0
 
-v4.0.2 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.2.0
+v4.1.0 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.2.0
 
 ### Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-ui-plugin-profile-materials",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-ui-plugin-profile-materials",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "ECL-2.0",
       "dependencies": {
         "cspace-ui-plugin-record-material": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-materials",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Materials Authority profile plugin for the CollectionSpace UI",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",


### PR DESCRIPTION
What does this do?
This updates the package version to 4.1.0 to signify the next release.

When the PR is merged we can publish the relevant draft release https://github.com/collectionspace/cspace-ui-plugin-profile-materials.js/releases/edit/untagged-193d194f9fa7b50129f3

