### PR TITLE
DRYD-2047: Update grid and detail list views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v4.1.1
+
+### Changes
+
+- Add configuration for the detail list and grid views for CollectionObjects in order to include the `material` field`.
+
 ## v4.1.0
 
 v4.1.0 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.2.0

--- a/src/plugins/recordTypes/collectionobject/detailList.jsx
+++ b/src/plugins/recordTypes/collectionobject/detailList.jsx
@@ -1,0 +1,26 @@
+export default (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    formatRefNameWithDefault,
+  } = configContext.formatHelpers;
+
+  return {
+    title: {
+      formatter: (data, { separator = ' ' } = {}) => {
+        const objectNumber = data.get('objectNumber');
+        const material = formatRefNameWithDefault(data.get('material'));
+
+        return (
+          <h2>
+            {objectNumber}
+            {material ? `${separator}${material}` : null}
+          </h2>
+        );
+      },
+    },
+
+  };
+};

--- a/src/plugins/recordTypes/collectionobject/detailList.jsx
+++ b/src/plugins/recordTypes/collectionobject/detailList.jsx
@@ -21,6 +21,5 @@ export default (configContext) => {
         );
       },
     },
-
   };
 };

--- a/src/plugins/recordTypes/collectionobject/grid.jsx
+++ b/src/plugins/recordTypes/collectionobject/grid.jsx
@@ -1,0 +1,19 @@
+export default (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    formatRefNameWithDefault,
+  } = configContext.formatHelpers;
+
+  return {
+    subtitle: {
+      formatter: (data) => {
+        const material = formatRefNameWithDefault(data.get('material'));
+        return material ? <p>{material}</p> : null;
+      },
+    },
+
+  };
+};

--- a/src/plugins/recordTypes/collectionobject/grid.jsx
+++ b/src/plugins/recordTypes/collectionobject/grid.jsx
@@ -14,6 +14,5 @@ export default (configContext) => {
         return material ? <p>{material}</p> : null;
       },
     },
-
   };
 };

--- a/src/plugins/recordTypes/collectionobject/index.js
+++ b/src/plugins/recordTypes/collectionobject/index.js
@@ -1,7 +1,9 @@
 import advancedSearch from './advancedSearch';
 import columns from './columns';
+import detailList from './detailList';
 import fields from './fields';
 import forms from './forms';
+import grid from './grid';
 import optionLists from './optionLists';
 
 export default () => (configContext) => ({
@@ -10,8 +12,10 @@ export default () => (configContext) => ({
     collectionobject: {
       advancedSearch: advancedSearch(configContext),
       columns: columns(configContext),
+      detailList: detailList(configContext),
       fields: fields(configContext),
       forms: forms(configContext),
+      grid: grid(configContext),
     },
   },
 });


### PR DESCRIPTION
**What does this do?**
* Updates the grid and detail views to include the material

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2047

The material profile uses the `material` field as a primary field for CollectionObjects. This provides that information in the new search result views.

**How should this be tested? Do these changes have associated tests?**
* Build CollectionSpace with the material profile enabled
* Create an Object with a material
* Search on Objects
  * In the grid view, the material should display underneath the object number
  * In the detail list view, the material should display in the title with the object number 

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
The changelog is soon to be updated

**Did someone actually run this code to verify it works?**
@mikejritter tested locally